### PR TITLE
Start of MSJ tests

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,41 @@
+# Plan: Conspire & Automesh Focus
+
+Focus on finite element quality metrics, specifically the Minimum Scaled Jacobian (MSJ), and its integration between `conspire` and `automesh`.
+
+## Phase 1: Coverage and Validation of MSJ in `conspire`
+
+1.  **Audit MSJ Implementation:**
+    *   Examine `minimum_scaled_jacobian` and `scaled_jacobians` for all linear hexahedral finite elements:
+        *   `src/domain/fem/block/element/linear/hexahedron/mod.rs`
+        *   `src/domain/fem/block/element/linear/tetrahedron/mod.rs`
+    * Ignore these for now:
+        *   `src/domain/fem/block/element/linear/wedge/mod.rs`
+        *   `src/domain/fem/block/element/linear/pyramid/mod.rs`
+        *   `src/domain/fem/block/element/surface/linear/triangle/mod.rs`
+        *   `src/domain/fem/block/element/surface/linear/quadrilateral/mod.rs`
+    *   Check for potential numerical stability issues (e.g., zero-length edges).
+2.  **Develop Test Suite for MSJ:**
+    *   Create a new test module or extend existing `test.rs` files for each element.
+    *   Test cases should include:
+        *   Ideal/Unit elements (MSJ should be 1.0 or close for equilateral/orthogonal elements).
+        *   Degenerate/Flat elements (MSJ should be 0.0).
+        *   Inverted elements (MSJ should be negative).
+        *   Perturbed/Distorted elements with known MSJ values.
+3.  **Global MSJ at Block Level:**
+    *   Verify `minimum_scaled_jacobians` in `src/domain/fem/block/mod.rs` correctly aggregates element-wise MSJ.
+    *   Add block-level tests for `Block::minimum_scaled_jacobians`.
+
+## Phase 2: Automesh Integration Research
+
+1.  **Analyze `automesh` Usage:**
+    *   Investigate `automesh/src/fem/hex/mod.rs` to see how `conspire::fem::block::element::linear::Hexahedron` is utilized.
+    *   Identify how `automesh` uses MSJ for mesh quality assessment or optimization.
+2.  **Bridge Improvements:**
+    *   Based on `automesh` needs, determine if additional metrics (e.g., Aspect Ratio, Skewness) or higher-order element support are needed in `conspire`.
+
+## Phase 3: Implementation and Refactoring
+
+1.  **Refactor for Performance/Clarity:**
+    *   Optimize MSJ calculations if necessary (e.g., reusing vector calculations).
+2.  **Sync with Automesh:**
+    *   Ensure `automesh` can seamlessly leverage the updated `conspire` features.

--- a/src/domain/fem/block/element/linear/hexahedron/mod.rs
+++ b/src/domain/fem/block/element/linear/hexahedron/mod.rs
@@ -76,7 +76,12 @@ impl FiniteElement<G, M, N, P> for Hexahedron {
                 v = &nodal_coordinates[node_b] - &nodal_coordinates[node];
                 w = &nodal_coordinates[node_c] - &nodal_coordinates[node];
                 n = u.cross(&v);
-                (&n * &w) / u.norm() / v.norm() / w.norm()
+                let product = u.norm() * v.norm() * w.norm();
+                if product > 0.0 {
+                    (&n * &w) / product
+                } else {
+                    0.0
+                }
             })
             .collect()
     }

--- a/src/domain/fem/block/element/linear/hexahedron/test.rs
+++ b/src/domain/fem/block/element/linear/hexahedron/test.rs
@@ -259,3 +259,63 @@ fn applied_velocities() -> (crate::math::Matrix, crate::math::Vector) {
 
 test_finite_element!(Hexahedron);
 test_finite_element_block!(Hexahedron);
+
+mod minimum_scaled_jacobian {
+    use super::*;
+    use crate::math::test::{TestError, assert_eq_within_tols};
+    /// Tests the scaled Jacobian calculation for an ideal, unit hexahedron.
+    ///
+    /// The expected value is 1.0.
+    #[test]
+    fn ideal() -> Result<(), TestError> {
+        let msj = Hexahedron::minimum_scaled_jacobian::<0>(reference_coordinates());
+        assert_eq_within_tols(&msj, &1.0)
+    }
+    /// Tests the scaled Jacobian calculation for a degenerate, flat hexahedron.
+    ///
+    /// The expected value is 0.0.
+    #[test]
+    fn flat() -> Result<(), TestError> {
+        let mut nodal_coordinates = reference_coordinates();
+        // Collapse upper face onto lower face.
+        nodal_coordinates[4] = nodal_coordinates[0].clone();
+        nodal_coordinates[5] = nodal_coordinates[1].clone();
+        nodal_coordinates[6] = nodal_coordinates[2].clone();
+        nodal_coordinates[7] = nodal_coordinates[3].clone();
+        let msj = Hexahedron::minimum_scaled_jacobian::<0>(nodal_coordinates);
+        assert_eq_within_tols(&msj, &0.0)
+    }
+    /// Tests the scaled Jacobian calculation for an inverted ideal hexahedron.
+    ///
+    /// The expected value is -1.0.
+    #[test]
+    fn inverted_ideal() -> Result<(), TestError> {
+        let mut nodal_coordinates = reference_coordinates();
+
+        // Swap the bottom face for the top, and vice versa.
+        let tmp0 = nodal_coordinates[0].clone();
+        let tmp1 = nodal_coordinates[1].clone();
+        let tmp2 = nodal_coordinates[2].clone();
+        let tmp3 = nodal_coordinates[3].clone();
+        let tmp4 = nodal_coordinates[4].clone();
+        let tmp5 = nodal_coordinates[5].clone();
+        let tmp6 = nodal_coordinates[6].clone();
+        let tmp7 = nodal_coordinates[7].clone();
+
+        nodal_coordinates[0] = tmp4;
+        nodal_coordinates[4] = tmp0;
+
+        nodal_coordinates[1] = tmp5;
+        nodal_coordinates[5] = tmp1;
+
+        nodal_coordinates[2] = tmp6;
+        nodal_coordinates[6] = tmp2;
+
+        nodal_coordinates[3] = tmp7;
+        nodal_coordinates[7] = tmp3;
+
+        let msj = Hexahedron::minimum_scaled_jacobian::<0>(nodal_coordinates);
+        // assert!(msj < 0.0);
+        assert_eq_within_tols(&msj, &-1.0)
+    }
+}


### PR DESCRIPTION
* Safeguard to avoid divide by zero error, useful for cases where an edge is collapsed.
* Three units tests as a start point: ideal, flat (collapsed), and inverted_idea.

