### PR TITLE
Trim by signed distance ratio rather than edge margin

### DIFF
--- a/src/geometry/mesh/tessellation/dual/mod.rs
+++ b/src/geometry/mesh/tessellation/dual/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod test;
+
 use crate::{
     geometry::{
         Coordinate, CoordinatesRef,
@@ -13,21 +16,7 @@ use crate::{
 use std::thread::{available_parallelism, scope};
 
 const GRAZING_TOLERANCE: Scalar = 1.0e-4;
-const TRIM_MARGIN: Scalar = 0.5;
-const EDGES: [[usize; 2]; 12] = [
-    [0, 1],
-    [1, 2],
-    [2, 3],
-    [3, 0],
-    [4, 5],
-    [5, 6],
-    [6, 7],
-    [7, 4],
-    [0, 4],
-    [1, 5],
-    [2, 6],
-    [3, 7],
-];
+const TRIM_RATIO: Scalar = 0.1;
 const DIRECTIONS: [Coordinate<D>; 3] = [
     Coordinate::const_from([1.0, 0.140_412_03, 0.092_153_88]),
     Coordinate::const_from([0.097_153_2, 1.0, 0.131_771_4]),
@@ -59,26 +48,23 @@ impl Tessellation {
         let directions = DIRECTIONS.map(|direction| direction.normalized());
         let coordinates = mesh.coordinates();
         let number_of_nodes = coordinates.len();
-        let mut inside = vec![false; number_of_nodes];
-        let mut clearance = vec![0.0; number_of_nodes];
+        let mut signed = vec![Scalar::NEG_INFINITY; number_of_nodes];
         let threads = available_parallelism().map_or(1, |threads| threads.get());
         let chunk_size = number_of_nodes.div_ceil(threads).max(1);
         scope(|scope| {
             let (elements, normals, directions) = (&elements, &normals, &directions);
-            inside
+            signed
                 .chunks_mut(chunk_size)
-                .zip(clearance.chunks_mut(chunk_size))
                 .enumerate()
-                .for_each(|(chunk, (flags, distances))| {
+                .for_each(|(chunk, distances)| {
                     scope.spawn(move || {
                         let offset = chunk * chunk_size;
-                        flags
+                        distances
                             .iter_mut()
-                            .zip(distances.iter_mut())
                             .enumerate()
-                            .for_each(|(local, (flag, distance))| {
+                            .for_each(|(local, distance)| {
                                 let point = &coordinates[offset + local];
-                                *flag = directions
+                                let inside = directions
                                     .iter()
                                     .find_map(|direction| {
                                         let ray = (point.clone(), direction.clone()).into();
@@ -93,25 +79,22 @@ impl Tessellation {
                                         }
                                     })
                                     .unwrap_or(false);
-                                if *flag
-                                    && let Some((closest, _)) =
-                                        bvh.closest_point(point, surface_coordinates, elements)
+                                if let Some((closest, _)) =
+                                    bvh.closest_point(point, surface_coordinates, elements)
                                 {
-                                    *distance = (&closest - point).norm();
+                                    let magnitude = (&closest - point).norm();
+                                    *distance = if inside { magnitude } else { -magnitude };
                                 }
                             });
                     });
                 });
         });
-        mesh.keep_hexes(|_, hex, coordinates| {
-            hex.iter().all(|&node| inside[node]) && {
-                let margin = TRIM_MARGIN
-                    * EDGES
-                        .iter()
-                        .map(|&[a, b]| (&coordinates[hex[a]] - &coordinates[hex[b]]).norm())
-                        .fold(Scalar::INFINITY, Scalar::min);
-                hex.iter().all(|&node| clearance[node] >= margin)
-            }
+        mesh.keep_hexes(|_, hex, _| {
+            let (minimum, maximum) = hex.iter().fold(
+                (Scalar::INFINITY, Scalar::NEG_INFINITY),
+                |(minimum, maximum), &node| (minimum.min(signed[node]), maximum.max(signed[node])),
+            );
+            minimum + TRIM_RATIO * maximum >= 0.0
         })
     }
 }

--- a/src/geometry/mesh/tessellation/dual/test.rs
+++ b/src/geometry/mesh/tessellation/dual/test.rs
@@ -1,0 +1,65 @@
+use crate::{
+    geometry::{
+        Coordinates,
+        mesh::{
+            Connectivity, Fitting, Mesh, Verdict,
+            tessellation::{D, Tessellation},
+        },
+        ntree::{Balancing, CurvatureSizing},
+    },
+    math::Scalar,
+};
+use std::f64::consts::TAU;
+
+fn torus(major: Scalar, minor: Scalar, around: usize, tube: usize) -> Tessellation {
+    let mut coordinates = Vec::new();
+    (0..around).for_each(|i| {
+        let theta = TAU * i as Scalar / around as Scalar;
+        (0..tube).for_each(|j| {
+            let phi = TAU * j as Scalar / tube as Scalar;
+            let radius = major + minor * phi.cos();
+            coordinates.push([
+                radius * theta.cos(),
+                radius * theta.sin(),
+                minor * phi.sin(),
+            ])
+        })
+    });
+    let index = |i: usize, j: usize| (i % around) * tube + (j % tube);
+    let faces: Vec<[usize; D]> = (0..around)
+        .flat_map(|i| {
+            (0..tube).flat_map(move |j| {
+                [
+                    [index(i, j), index(i + 1, j), index(i + 1, j + 1)],
+                    [index(i, j), index(i + 1, j + 1), index(i, j + 1)],
+                ]
+            })
+        })
+        .collect();
+    Tessellation::from(Mesh::from((
+        vec![Connectivity::Triangular(faces.into())],
+        Coordinates::from(coordinates),
+    )))
+}
+
+/// A slender torus at a coarse scale is where trimming back too far shows up:
+/// the buffer layer ends up spanning a gap the core should have covered. The
+/// `s_max/2` margin rule inverted 41 elements here (worst scaled Jacobian
+/// -0.5748); the signed-distance ratio rule leaves none.
+#[test]
+fn dualize_slender_torus_is_not_inverted() {
+    let mesh = torus(1.0, 0.15, 64, 24)
+        .dualize(
+            Balancing::Strong(1),
+            3.0,
+            CurvatureSizing::default(),
+            Fitting::Snap,
+        )
+        .unwrap();
+    let worst = mesh
+        .minimum_scaled_jacobians()
+        .into_iter()
+        .flatten()
+        .fold(Scalar::INFINITY, Scalar::min);
+    assert!(worst > 0.15, "{worst}");
+}

--- a/src/geometry/mesh/tessellation/dual/test.rs
+++ b/src/geometry/mesh/tessellation/dual/test.rs
@@ -42,10 +42,6 @@ fn torus(major: Scalar, minor: Scalar, around: usize, tube: usize) -> Tessellati
     )))
 }
 
-/// A slender torus at a coarse scale is where trimming back too far shows up:
-/// the buffer layer ends up spanning a gap the core should have covered. The
-/// `s_max/2` margin rule inverted 41 elements here (worst scaled Jacobian
-/// -0.5748); the signed-distance ratio rule leaves none.
 #[test]
 fn dualize_slender_torus_is_not_inverted() {
     let mesh = torus(1.0, 0.15, 64, 24)


### PR DESCRIPTION
## What

`Tessellation::trim` now keeps a hex when `f_min + 0.1*f_max >= 0` over its eight corner signed distances, replacing the all-nodes-inside plus half-min-edge clearance test. This is the per-hex SDF rule from Tong et al. 2024 (*HybridOctree_Hex*, JoCS 78:102278) §2.3.

Drops `TRIM_MARGIN` and the `EDGES` table, adds `TRIM_RATIO`. Net −20 lines in `dual/mod.rs`.

## Why

The old rule cut back too far on slender geometry. Two consequences: the buffer layer had to span a gap the core should have covered, and at coarse scales the core could erode away almost entirely.

The ratio needs no element-size term because the signed distance is 1-Lipschitz: `f_max <= f_min + diagonal` bounds any protrusion at ~9% of a hex diagonal, at any scale. That is what makes a dimensionless ratio safe, and why it beats the `s_max/2` family.

## Evidence

Measured both rules on the same fixtures (worst scaled Jacobian / inverted elements):

| fixture | old | new |
|---|---|---|
| bone s2 | **-0.3923 / 3 inverted** | 0.2279 / 0 |
| bone s3 | 0.0086 (near-degenerate, 839 hexes) | 0.2116 / 0 |
| bone s4 | 0.2518 | 0.3364 |
| bone s5 | 0.2589 | 0.2239 |
| bone s8 | 0.1677 | 0.2329 |
| torus r/R=0.15 s3 | **-0.5748 / 41 inverted** | 0.1845 / 0 |
| torus r/R=0.08 s3 | **-0.5687 / 55 inverted** | 0.2724 / 0 |
| torus r/R=0.15 s4 | 0.2009 | 0.3074 |
| torus r/R=0.15 s6 | 0.2804 | 0.3998 |
| cube s8 | 0.2843 | 0.4784 |
| sphere s4 | 0.4951 | 0.4322 |

Three cases that produced inverted elements now produce none.

## Costs

- **Element count up 1.2x (bone) to 3.5x (slender).** Not waste: it is core the old rule was eroding away and handing to the buffer to span.
- **bone s5 regresses** 0.2589 -> 0.2239. The only quality regression on bone; sphere s4 is the only other one anywhere.

## Tests

Adds `dualize_slender_torus_is_not_inverted`. `Tessellation::dualize` and `trim` previously had **zero** coverage. Mutation-verified: fails at -0.5748 under the old rule, passes at 0.1845 under the new one; runs in ~5s.

All 951 geometry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)